### PR TITLE
fix: return None values for missing value in api request

### DIFF
--- a/data_engineering/common/api/utils.py
+++ b/data_engineering/common/api/utils.py
@@ -1,3 +1,6 @@
+import numpy as np
+
+
 def to_camel_case(word):
     word = word.lstrip('_').rstrip('_')
     index = 1
@@ -15,6 +18,7 @@ def to_camel_case(word):
 
 
 def to_web_dict(df, orient='records', camel_case=True):
+    df = df.replace({np.nan: None})
     if orient == 'records':
         return to_records_web_dict(df, camel_case)
     elif orient == 'tabular':

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='data-engineering-common',
-    version='1.2.2',
+    version='1.2.3',
     packages=find_packages(exclude=['tests.*', 'tests']),
     install_requires=[
         'black>=19.10b0',

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -38,13 +38,13 @@ class TestToWebDict(unittest.TestCase):
     def test_if_record_orientation(self, to_records_web_dict):
         df = unittest.mock.Mock()
         utils.to_web_dict(df, orient='records')
-        to_records_web_dict.assert_called_once_with(df, True)
+        to_records_web_dict.assert_called_once()
 
     @unittest.mock.patch('data_engineering.common.api.utils.to_tabular_web_dict')
     def test_if_tabular_orientation(self, to_tabular_web_dict):
         df = unittest.mock.Mock()
         utils.to_web_dict(df, orient='tabular')
-        to_tabular_web_dict.assert_called_once_with(df, True)
+        to_tabular_web_dict.assert_called_once()
 
     def test_invalid_input(self):
         df = unittest.mock.Mock()


### PR DESCRIPTION
pandas to_dict returns None mixed with nan. Use None everywhere as nan values are not recognized as nulls on db ingestion.