### PR TITLE
feat: changes to support SQLAlchemy >= 2, and Pandas >= 2

### DIFF
--- a/data_engineering/common/db/models.py
+++ b/data_engineering/common/db/models.py
@@ -93,7 +93,8 @@ class BaseModel(db.Model):
         query = cls.query
         if columns:
             query = query.options(load_only(*columns))
-        return pd.read_sql(query.statement, db.engine, index_col=cls.id.description)
+        with db.engine.connect() as conn:
+            return pd.read_sql(query.statement, conn, index_col=cls.id.description)
 
 
 def create_schemas(*args, **kwargs):

--- a/data_engineering/common/tests/utils.py
+++ b/data_engineering/common/tests/utils.py
@@ -54,7 +54,7 @@ def row_to_sortable_tuple(row):
 def assert_dfs_equal_ignore_dtype(df1, df2):
     df1 = _sort_columns(df1)
     df2 = _sort_columns(df2)
-    pd.util.testing.assert_frame_equal(df1, df2, check_dtype=False, check_index_type=False)
+    pd.testing.assert_frame_equal(df1, df2, check_dtype=False, check_index_type=False)
 
 
 def _sort_columns(df):

--- a/data_engineering/common/views/base.py
+++ b/data_engineering/common/views/base.py
@@ -24,8 +24,8 @@ class PaginatedListView(View):
         pagination_values = []
 
         if next_id is not None:
-            pagination_clause = 'where id >= %s'
-            pagination_values = [next_id]
+            pagination_clause = 'where id >= :next_id'
+            pagination_values = [{'next_id': next_id}]
 
         sql_query = f'''
             select id, {self.get_select_clause()}


### PR DESCRIPTION
To support SQLAlchemy 2 (which seems to also then require Pandas >= 2 for its read_sql function) we need to:

For SQLAlchemy >= 2
- Always wrap SQL strings with the `text` method
- Use named parameters in SQL strings with dictionaries as the values of the parameters.

For Pandas >= 2
- Connect to the database outside of the pandas read_sql function in our own context
- Use pd.testing.assert_frame_equal rather than pd.util.testing.assert_frame_equal

Doing this in the one change rather than two because of the interplay between SQLAlchemy and Pandas in read_sql.

This is part of work of getting https://github.com/uktrade/data-store-service to build with the recent changes of https://github.com/uktrade/data-engineering-common/pull/34 that bumped SQLAlchemy to >= 2. The changes here fix a number of errors in data-store-service's testing suite.

To actually test the data-store-service before merge of this change, its requirements.txt file had to be changed to refer to the specific commit in this PR, for example:

```
data-engineering-common @ git+https://github.com/uktrade/data-engineering-common.git@COMMIT_ID
```
(replacing `COMMIT_ID` with the actual commit being tested)