### PR TITLE
feat: better logging when there is an exception in an endpoint

### DIFF
--- a/data_engineering/common/views/__init__.py
+++ b/data_engineering/common/views/__init__.py
@@ -62,7 +62,7 @@ def json_error(f):
         except Unauthorized:
             response = make_response('', 401)
         except Exception as e:
-            flask_app.logger.error(f'unexpected exception for API request: {str(e)}')
+            flask_app.logger.exception(f'unexpected exception for API request: {str(e)}')
             response = make_response('', 500)
         return response
 


### PR DESCRIPTION
As part of getting the data-store-service at
https://github.com/uktrade/data-store-service to build with recent changes in https://github.com/uktrade/data-engineering-common/pull/34, it's easier to see the full trace of exceptions in the log, which logger.exception should do